### PR TITLE
run-tests.sh: Use pkgconfig instead of deprecated cups-config

### DIFF
--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -251,9 +251,9 @@ esac
 # components from there
 #
 
-sys_datadir=`cups-config --datadir`
-sys_serverbin=`cups-config --serverbin`
-sys_serverroot=`cups-config --serverroot`
+sys_datadir=`pkg-config --variable=cups_datadir cups`
+sys_serverbin=`pkg-config --variable=cups_serverbin cups`
+sys_serverroot=`pkg-config --variable=cups_serverroot cups`
 
 #
 # Pseudo-random number (nanoseconds of "date") as prefix for


### PR DESCRIPTION
cups-config is deprecated in cups 2.4.x series, let's use pkgconfig for getting the CUPS directories.