### PR TITLE
Fix the daemon crash when Get-Printer-Attributes fails

### DIFF
--- a/daemon/cups-browsed.c
+++ b/daemon/cups-browsed.c
@@ -7815,8 +7815,11 @@ create_remote_printer_entry (const char *queue_name,
       p->prattrs = cfGetPrinterAttributes(p->uri, NULL, 0, NULL, 0, 1);
       debug_log_out(cf_get_printer_attributes_log);
       if (p->prattrs == NULL)
+      {
 	debug_printf("get-printer-attributes IPP call failed on printer %s (%s).\n",
 		     p->queue_name, p->uri);
+	goto fail;
+      }
     }
   }
   else


### PR DESCRIPTION
cups-browsed crashed when it found remote CUPS queue shared by mDNS on local network, but IPP request for this queue failed. The empty prattrs is later accessed, which causes the crash.

Fixed by jumping to the point where failed attempts ends when we don't get the IPP response.