### PR TITLE
Init variables which can be later used uninitialized

### DIFF
--- a/daemon/cups-browsed.c
+++ b/daemon/cups-browsed.c
@@ -10889,7 +10889,7 @@ resolve_callback(void* arg)
   AVAHI_GCC_UNUSED void* userdata = a->userdata;
 
   char ifname[IF_NAMESIZE];
-  AvahiStringList *uuid_entry, *printer_type_entry;
+  AvahiStringList *uuid_entry = NULL, *printer_type_entry;
   char *uuid_key, *uuid_value;
 
   debug_printf("resolve_callback() in THREAD %ld\n", pthread_self());
@@ -11166,6 +11166,12 @@ resolve_callback(void* arg)
   }
 
  ignore:
+  if (uuid_entry)
+  {
+    avahi_free(uuid_key);
+    avahi_free(uuid_value);
+  }
+
   if (a->name) free((char*)a->name);
   if (a->type) free((char*)a->type);
   if (a->domain) free((char*)a->domain);

--- a/daemon/cups-browsed.c
+++ b/daemon/cups-browsed.c
@@ -6935,7 +6935,7 @@ on_job_state (CupsNotifier *object,
 
       // The priority order for the PDLs is the same as in the
       // PPD generator in ppd/ppd-generator.c of libppd
-      document_format = (char *)malloc(sizeof(char) * 32);
+      document_format = (char *)calloc(32, sizeof(char));
       if (cupsArrayFind(pdl_list, "application/vnd.cups-pdf"))
 	strcpy(document_format, "application/vnd.cups-pdf");
       else if (cupsArrayFind(pdl_list, "image/urf"))
@@ -10951,7 +10951,7 @@ resolve_callback(void* arg)
   // Called whenever a service has been resolved successfully
 
   // New remote printer found
-  AvahiStringList *rp_entry, *adminurl_entry;
+  AvahiStringList *rp_entry = NULL, *adminurl_entry = NULL;
   char *rp_key, *rp_value, *adminurl_key, *adminurl_value;
 
   debug_printf("Avahi Resolver: Service '%s' of type '%s' in domain '%s' with host name '%s' and port %d on interface '%s' (%s).\n",


### PR DESCRIPTION
I ran [openscanhub](https://github.com/openscanhub/openscanhub) tool on cups-browsed code and fixed some of the important issues it reports - usage of uninitialized memory in the code.

Here are [results](https://github.com/OpenPrinting/cups-browsed/files/14194846/scan-results-imp.txt) - I didn't fix Y2K38_SAFETY and REVERSE_NEGATIVE, because:

Y2K38_SAFETY: timeout used there will never be that high to overflow - it is subtraction of current time from expected timeout of queue.

REVERSE_NEGATIVE: the value mentioned there comes from Avahi, so Avahi should take care of it being in valid interval.
