### PR TITLE
cups-browsed.c: Ignore attributes with empty values

### DIFF
--- a/daemon/cups-browsed.c
+++ b/daemon/cups-browsed.c
@@ -5975,6 +5975,13 @@ record_printer_options(const char *printer)
 		memmove(c, c + 1, strlen(c));
 	      if (*c) c ++;
 	    }
+
+	    if (strlen(buf) == 0)
+	    {
+	      attr = ippNextAttribute(response);
+	      continue;
+	    }
+
 	    debug_printf("   %s=%s\n", key, buf);
 	    p->num_options = cupsAddOption(key, buf, p->num_options,
 					   &(p->options));


### PR DESCRIPTION
Previously, if IPP attribute value was empty, cups-browsed saved the attribute as printer option "<name>=0", e.g. `orientation-requested=0`. In case of `orientation-requested` zero is an invalid value, but it is ignored in case printer clusters are not in use.

However, if clustering is used, cups-browsed tries to find a printer in cluster which supports `orientation-requested=0` and finds none, since the value is invalid, ending up with print job error.

Of course, this could be solved by initializing the value in cupsd or by a conversion mechanism in cups-browsed, but the former would set an unneeded default, and the latter would add logic overhaul which can be source of errors.

In my opinion, we should make change in IPP attribute processing, and ignore the attributes with empty values when we set up printer options which we save.