### PR TITLE
cups-browsed.c: Ignore attributes with "no-value"

### DIFF
--- a/daemon/cups-browsed.c
+++ b/daemon/cups-browsed.c
@@ -5956,6 +5956,12 @@ record_printer_options(const char *printer)
       attr = ippFirstAttribute(response);
       while (attr)
       {
+	if (ippGetValueTag(attr) == IPP_TAG_NOVALUE)
+	{
+	  attr = ippNextAttribute(response);
+	  continue;
+	}
+
 	key = ippGetName(attr);
 	for (ptr = attrs_to_record; *ptr; ptr++)
 	  if (strcasecmp(key, *ptr) == 0 ||


### PR DESCRIPTION
We don't need to record attributes with IPP_TAG_NOVALUE value tag, cupsd will decide what value to use for the attribute based on incoming document.