### PR TITLE
daemon/cups-browsed.service: add system-cups.slice

### DIFF
--- a/daemon/cups-browsed.service
+++ b/daemon/cups-browsed.service
@@ -6,6 +6,7 @@ Wants=avahi-daemon.service network-online.target
 
 [Service]
 ExecStart=/usr/sbin/cups-browsed
+Slice=system-cups.slice
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
See https://github.com/OpenPrinting/cups/pull/1035 for rationale and an explanation.

The ``system-cups.slice`` file included in the aforementioned PR is not required; the ``system-cups`` slice will be automatically created if the file is missing.