### PR TITLE
cups-browsed.c: remove duplicate include

### DIFF
--- a/daemon/cups-browsed.c
+++ b/daemon/cups-browsed.c
@@ -116,7 +116,6 @@ static int  ldap_rebind_proc(LDAP *RebindLDAPHandle,
 #include <cups/cups.h>
 #include <cups/raster.h>
 #include <cupsfilters/ipp.h>
-#include <cupsfilters/ipp.h>
 #include <ppd/ppd.h>
 
 #include "cups-notifier.h"


### PR DESCRIPTION
This commit will remove a duplicate #include.