### PR TITLE
Add BrowseOptionsUpdate directive

### DIFF
--- a/daemon/cups-browsed.conf.5
+++ b/daemon/cups-browsed.conf.5
@@ -946,6 +946,7 @@ and doing specific actions when a D-BUS notification comes.
 .nf
 .fam C
         NotifLeaseDuration 86400
+
 .fam T
 .fi
 FrequentNetifUpdate turns on/off the network interface update routines
@@ -958,6 +959,25 @@ is 'Yes'.
 .nf
 .fam C
         FrequentNetifUpdate Yes
+
+.fam T
+.fi
+BrowseOptionsUpdate directive defines how default printing options are updated when
+cups-browsed is running. The value "None" uses default values from destination
+at discovery and overrides them by values from the file "/var/cache/cups/cups-browsed-options-<queue-name>"
+if it is present from the previous cups-browsed run. The value "Static" does not save default
+options between runs and do not read them from file if the cached file exists. The default options
+are statically set at the first discovery and cups-browsed restart is required to synchronize
+new default options from destinations. The value "Dynamic" causes cups-browsed to update default
+options at every "BrowseInterval" event to synchronize with destination's default options automatically.
+With "Static" and "Dynamic" user are able to change default options values locally via "lpoptions". 
+.PP
+.nf
+.fam C
+        BrowseOptionsUpdate None
+        BrowseOptionsUpdate Static
+        BrowseOptionsUpdate Dynamic
+
 .fam T
 .fi
 .SH SEE ALSO

--- a/daemon/cups-browsed.conf.in
+++ b/daemon/cups-browsed.conf.in
@@ -745,3 +745,17 @@ BrowseRemoteProtocols @BROWSEREMOTEPROTOCOLS@
 # is 'Yes'.
 #
 # FrequentNetifUpdate Yes
+
+# BrowseOptionsUpdate directive defines how default printing options are updated when
+# cups-browsed is running. The value "None" uses default values from destination
+# at discovery and overrides them by values from the file "/var/cache/cups/cups-browsed-options-<queue-name>"
+# if it is present from the previous cups-browsed run. The value "Static" does not save default
+# options between runs and do not read them from file if the cached file exists. The default options
+# are statically set at the first discovery and cups-browsed restart is required to synchronize
+# new default options from destinations. The value "Dynamic" causes cups-browsed to update default
+# options at every BrowseInterval event to synchronize with destination's default options automatically.
+# With "Static" and "Dynamic" user are able to change default options values locally via "lpoptions". 
+#
+# BrowseOptionsUpdate None
+# BrowseOptionsUpdate Static
+# BrowseOptionsUpdate Dynamic


### PR DESCRIPTION
The directive influences where default options are taken from and whether they can be updated. This way admins can propagate defaults to clients automatically if the client opts-in for the behavior.

It is useful for DNS-SD found services as well, but currently only with "Static" value, because DNS-SD browsing is not currently affected by BrowseInterval value used in dynamic  method.