### PR TITLE
Bound UIConstraints formatting to fix stack overflow (OCU-01-007)

### DIFF
--- a/daemon/cups-browsed.c
+++ b/daemon/cups-browsed.c
@@ -2803,12 +2803,14 @@ generate_cluster_conflicts(char *cluster_name,
 		continue;
 	      if (!strcmp(opt1, "Gray") || !strcmp(opt2, "Gray"))
 		continue;
-	      sprintf(constraint, "*UIConstraints: *%s %s *%s %s\n",
+	      snprintf(constraint, sizeof(constraint),
+		      "*UIConstraints: *%s %s *%s %s\n",
 		      ppd_keywords[i],
 		      opt1,ppd_keywords[k], opt2);
 	      if (!cupsArrayFind(conflict_pairs, constraint))
 		cupsArrayAdd(conflict_pairs, constraint);
-	      sprintf(constraint, "*UIConstraints: *%s %s *%s %s\n",
+	      snprintf(constraint, sizeof(constraint),
+		      "*UIConstraints: *%s %s *%s %s\n",
 		      ppd_keywords[k],
 		      opt2, ppd_keywords[i], opt1);
 	      if (!cupsArrayFind(conflict_pairs, constraint))


### PR DESCRIPTION
### What this fixes

Fixes #59  (audit finding OCU-01-007).

`generate_cluster_conflicts()` formats `*UIConstraints` lines into a fixed `char[100]` stack buffer using `sprintf` with no length check. The option names come from remote-printer capability keywords, so a printer advertising long but valid keywords can push the formatted string past 100 bytes and overflow the buffer in the cups-browsed daemon during clustered queue generation.

### The fix

Both `sprintf(constraint, ...)` calls become `snprintf(constraint, sizeof(constraint), ...)`, bounding the write to the buffer. A pathological constraint is now truncated rather than overflowing.