### PR TITLE
Reject wrong-tag media keywords in get_mediadata (OCU-01-010)

### DIFF
--- a/daemon/cups-browsed.c
+++ b/daemon/cups-browsed.c
@@ -1131,6 +1131,12 @@ pwg_ppdize_name(const char *ipp,      // I - IPP keyword
   char  *ptr,       // Pointer into name buffer
         *end;       // End of name buffer
 
+  if (ipp == NULL || *ipp == '\0')
+  {
+    *name = '\0';
+    return;
+  }
+
   *name = (char)toupper(*ipp++);
 
   for (ptr = name + 1, end = name + namesize - 1; *ipp && ptr < end;)
@@ -2008,12 +2014,14 @@ get_mediadata(ipp_t *printer_attributes,
 				  (cups_afree_func_t)free)) == NULL)
     return (NULL);
   if ((attr = ippFindAttribute(printer_attributes, requested_option,
-			       IPP_TAG_ZERO)) != NULL
+			       IPP_TAG_KEYWORD)) != NULL
       && (count = ippGetCount(attr)) > 1)
   {
     for (i = 0, count = ippGetCount(attr); i < count; i ++)
     {
       keyword = ippGetString(attr, i, NULL);
+      if (keyword == NULL)
+	continue;
       pwg_ppdize_name(keyword, ppdname, sizeof(ppdname));
       cupsArrayAdd(media_data, ppdname);
     }


### PR DESCRIPTION
### What this fixes

Fixes #61 (audit finding OCU-01-010).

`get_mediadata()` looks up `media-type-supported` / `media-source-supported` / `output-bin-supported` with `IPP_TAG_ZERO`, then passes the `ippGetString()` result straight into `pwg_ppdize_name()`. A remote printer can send one of these with a non-string tag, so `ippGetString()` returns NULL and `pwg_ppdize_name()` crashes on `toupper(*ipp++)`.

### The changes

- `get_mediadata()` now requires `IPP_TAG_KEYWORD` and skips any NULL `ippGetString()` result before calling `pwg_ppdize_name()`.
- Added a NULL/empty guard at the top of `pwg_ppdize_name()` itself, so its other callers can't hit the same crash. This matches how `ppdPwgPpdizeName()` in libppd already handles NULL.

Normal printers are unaffected — real media keywords are keyword-tagged and non-NULL.