### PR TITLE
Fix heap overflow formatting enum/integer values (OCU-01-011)

### DIFF
--- a/daemon/cups-browsed.c
+++ b/daemon/cups-browsed.c
@@ -1422,7 +1422,7 @@ add_enum_attributes(char* cluster_name,
 			      (cups_acopy_func_t)strdup,
 			      (cups_afree_func_t)free)) == NULL)
       return ;
-    str = malloc(sizeof(char) * 10);
+    str = malloc(sizeof(char) * 16);
     num_value = 0;
     for (p = (remote_printer_t *)cupsArrayFirst(remote_printers);
          p; p = (remote_printer_t *)cupsArrayNext(remote_printers))
@@ -1439,7 +1439,7 @@ add_enum_attributes(char* cluster_name,
         for (i = 0; i < count; i ++)
 	{
           value = ippGetInteger(attr, i);
-          sprintf(str,"%d",value);
+          snprintf(str, 16, "%d", value);
           if (!cupsArrayFind(list, (void *)str))
 	  {
             cupsArrayAdd(list, (void *)str);
@@ -1497,7 +1497,7 @@ add_margin_attributes(char* cluster_name,
 			      (cups_acopy_func_t)strdup,
 			      (cups_afree_func_t)free)) == NULL)
       return ;
-    str = malloc(sizeof(char)*10);
+    str = malloc(sizeof(char)*16);
     num_value = 0;
     for (p = (remote_printer_t *)cupsArrayFirst(remote_printers);
          p; p = (remote_printer_t *)cupsArrayNext(remote_printers))
@@ -1514,7 +1514,7 @@ add_margin_attributes(char* cluster_name,
         for (i = 0; i < count; i++)
 	{
           value = ippGetInteger(attr, i);
-          sprintf(str,"%d",value);
+          snprintf(str, 16, "%d", value);
           if (!cupsArrayFind(list, (void *)str))
 	  {
             cupsArrayAdd(list, (void *)str);


### PR DESCRIPTION
### What this fixes

Fixes #63 (audit finding OCU-01-011).

`add_enum_attributes()` formats remote IPP integer values into a 10-byte heap buffer with `sprintf("%d", value)`. A 32-bit signed int can be up to 12 bytes (`-2147483648` plus the NUL), so a large value from a remote printer writes past the allocation and corrupts the heap in the cups-browsed daemon during cluster merging.

### The changes

- Grow the buffer from 10 to 16 bytes (enough for any 32-bit signed int plus NUL) and use `snprintf` to bound the write.
- Applied the same fix to `add_margin_attributes()` just below, which has the identical `malloc(10)` + `sprintf("%d")` pattern reading integer values.

No behavioural change; normal values format exactly as before.