### PR TITLE
Reject wrong-tag cluster-merge attributes (OCU-01-012)

### DIFF
--- a/daemon/cups-browsed.c
+++ b/daemon/cups-browsed.c
@@ -1271,7 +1271,7 @@ add_tagzero_attributes(char* cluster_name,
 	  p->status ==  STATUS_TO_BE_RELEASED)
 	continue;
       if ((attr = ippFindAttribute(p->prattrs, attributes[attr_no],
-				   IPP_TAG_KEYWORD)) != NULL)
+				   IPP_TAG_ZERO)) != NULL)
       {
 	count = ippGetCount(attr);
 	for(i = 0; i < count; i ++)

--- a/daemon/cups-browsed.c
+++ b/daemon/cups-browsed.c
@@ -1271,13 +1271,15 @@ add_tagzero_attributes(char* cluster_name,
 	  p->status ==  STATUS_TO_BE_RELEASED)
 	continue;
       if ((attr = ippFindAttribute(p->prattrs, attributes[attr_no],
-				   IPP_TAG_ZERO)) != NULL)
+				   IPP_TAG_KEYWORD)) != NULL)
       {
 	count = ippGetCount(attr);
 	for(i = 0; i < count; i ++)
 	{
 	  // Pick next format from attribute
 	  str = ippGetString(attr, i, NULL);
+	  if (str == NULL)
+	    continue;
 	  // Add format to list, skip duplicates
 	  if (!cupsArrayFind(list, (void *)str))
 	  {


### PR DESCRIPTION
### What this fixes

Fixes #65 (audit finding OCU-01-012).

`add_tagzero_attributes()` looks up five capability attributes with `IPP_TAG_ZERO`, then passes the `ippGetString()` results into a CUPS array and later into `strlen()` when building the `values[]` array for `ippAddStrings()`. A remote printer can send one of these with a non-string tag, so `ippGetString()` returns NULL and cups-browsed crashes during cluster merging.

### The changes

- Look these attributes up with `IPP_TAG_KEYWORD` instead of `IPP_TAG_ZERO`.
- Skip any NULL `ippGetString()` result before it's added to the list.

The count passed to `ippAddStrings()` stays correct on its own, since it's only incremented when a value is actually added — so a skipped NULL never inflates it.

Normal printers are unaffected — these are keyword attributes in practice.