### PR TITLE
fix sock leaks in update_cups_queues

### DIFF
--- a/daemon/cups-browsed.c
+++ b/daemon/cups-browsed.c
@@ -8477,6 +8477,7 @@ update_cups_queues(gpointer unused)
 		  disable_printer(p->queue_name,
 				  "Printer disappeared or cups-browsed shutdown");
 		// Schedule the removal of the queue for later
+		httpClose(http);
 		if (in_shutdown == 0)
 		{
 		  current_time = time(NULL);
@@ -8505,6 +8506,7 @@ update_cups_queues(gpointer unused)
 		  is_cups_default_printer(p->queue_name))
 	      {
 		// Schedule the removal of the queue for later
+		httpClose(http);
 		if (in_shutdown == 0)
 		{
 		  current_time = time(NULL);
@@ -8547,6 +8549,7 @@ update_cups_queues(gpointer unused)
 		  current_time = time(NULL);
 		  p->timeout = current_time + TIMEOUT_RETRY;
 		  p->no_autosave = 0;
+		  httpClose(http);
 		  break;
 		}
 	      }


### PR DESCRIPTION
When a printer is gone it may still have jobs queued: easiest way to reproduce is to pause the printer, submit a job, then turn the printer off.

In that case the daemon drops into the error paths when trying to remove the printer. Unfortunately many error paths leak the cups domain socket, exhausting the available file descriptors quickly.

The socket is allocated in one of the switch cases. That means break statements exit the switch block without closing the socket. The goto statements jump past the close call too.

Properly close the socket in the error paths of the relevant function.