### PR TITLE
Add multi-architecture / multi-CUPS CI and fix build against CUPS 2.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,144 @@
+# =============================================================================
+# Multi-Architecture / multi-CUPS Build & Test Workflow for cups-browsed
+#
+# Matrix: 4 architectures x 2 CUPS releases = 8 combinations.
+#   architectures: amd64, arm64 (native runners); armhf, riscv64 (QEMU)
+#   CUPS releases: 2.4.x (distro libcups2-dev), 2.5.x (OpenPrinting/cups master)
+#
+# cups-browsed does NOT make sense on CUPS 3.x, so libcups3 is intentionally
+# excluded (2 CUPS releases, not 3).
+#
+# cups-browsed needs libcups AND libcupsfilters AND libppd.  For the source-CUPS
+# leg the distro libcupsfilters-dev / libppd-dev are the wrong ABI, so
+# ci/ci-setup.sh builds the whole chain (pdfio -> libcupsfilters -> libppd) from
+# source against the active CUPS.  All the per-combination work lives in that
+# script so the legs differ only in which CUPS is provided and whether they run
+# under emulation.
+# =============================================================================
+name: Build and Test (cups-browsed, Multi-Architecture, Multi-CUPS)
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-matrix:
+    name: Build & Test (${{ matrix.arch }}, ${{ matrix.cups }})
+    runs-on: ${{ matrix.runs-on }}
+    # The source-2.5.x leg builds its CUPS / libcupsfilters / libppd from
+    # OpenPrinting @master, an unpinned moving target: a transient breakage there
+    # reddens the leg through no fault of cups-browsed.  Keep the distro
+    # system-2x leg required (blocking), but let the source-@master leg report
+    # without blocking the PR.  ci-setup.sh annotates each failure as
+    # UPSTREAM-DEP-FAILED vs CUPS-BROWSED-FAILED so a real cups-browsed
+    # regression on the source leg is still visible even while non-blocking.
+    continue-on-error: ${{ matrix.cups != 'system-2x' }}
+    # Building the CUPS / libcupsfilters / libppd stack from source under QEMU is
+    # slow; allow plenty.
+    timeout-minutes: 360
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64, armhf, riscv64]
+        cups: [system-2x, source-2.5.x]
+        include:
+          - arch: amd64
+            runs-on: ubuntu-latest
+            use-qemu: false
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
+            use-qemu: false
+          - arch: armhf
+            runs-on: ubuntu-latest
+            use-qemu: true
+            qemu-arch: armv7
+          - arch: riscv64
+            runs-on: ubuntu-latest
+            use-qemu: true
+            qemu-arch: riscv64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ==========================================
+      # NATIVE EXECUTION (amd64 and arm64)
+      # ==========================================
+      - name: Build (Native)
+        if: matrix.use-qemu == false
+        env:
+          CUPS_KIND: ${{ matrix.cups }}
+          EMULATED: "0"
+        run: |
+          set -ex
+          sh ci/ci-setup.sh deps
+          sh ci/ci-setup.sh cups "${{ matrix.cups }}"
+          sh ci/ci-setup.sh pdfio
+          sh ci/ci-setup.sh libcupsfilters "${{ matrix.cups }}"
+          sh ci/ci-setup.sh libppd "${{ matrix.cups }}"
+          sh ci/ci-setup.sh build-cups-browsed
+
+      # NOTE: cups-browsed's functional suite (test/run-tests.sh) is a full
+      # DNS-SD queue-creation + print round-trip against a private cupsd and two
+      # ippeveprinter instances.  It needs a live D-Bus + Avahi/mDNS environment
+      # that is not reliably available on GitHub runners, so it is intentionally
+      # not run here; wiring it up is tracked as a follow-up.  This matrix
+      # verifies that cups-browsed builds and links across every supported
+      # architecture and CUPS release - which is what caught the CUPS 2.5 API
+      # breakage this workflow was first added against.
+
+      - name: Upload test artifacts (Native)
+        if: matrix.use-qemu == false && always()
+        continue-on-error: true
+        timeout-minutes: 5
+        uses: actions/upload-artifact@v4
+        with:
+          name: cups-browsed-logs-${{ matrix.arch }}-${{ matrix.cups }}
+          path: |
+            config.log
+          if-no-files-found: ignore
+
+      # ==========================================
+      # EMULATED EXECUTION (armhf and riscv64)
+      # Build/link only - the DNS-SD functional test is unreliable under QEMU.
+      # ==========================================
+      - name: Build (Emulated)
+        if: matrix.use-qemu == true
+        uses: uraimo/run-on-arch-action@v3
+        with:
+          arch: ${{ matrix.qemu-arch }}
+          distro: ubuntu24.04
+          githubToken: ${{ github.token }}
+          install: |
+            apt-get update --fix-missing -y
+            DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata ca-certificates git
+          run: |
+            set -ex
+            export CUPS_KIND="${{ matrix.cups }}"
+            export EMULATED=1
+            sh ci/ci-setup.sh deps
+            sh ci/ci-setup.sh cups "${{ matrix.cups }}"
+            sh ci/ci-setup.sh pdfio
+            sh ci/ci-setup.sh libcupsfilters "${{ matrix.cups }}"
+            sh ci/ci-setup.sh libppd "${{ matrix.cups }}"
+            sh ci/ci-setup.sh build-cups-browsed
+
+      - name: Upload test artifacts (Emulated)
+        if: matrix.use-qemu == true && always()
+        continue-on-error: true
+        timeout-minutes: 5
+        uses: actions/upload-artifact@v4
+        with:
+          name: cups-browsed-logs-${{ matrix.arch }}-${{ matrix.cups }}
+          path: |
+            config.log
+          if-no-files-found: ignore

--- a/ci/ci-setup.sh
+++ b/ci/ci-setup.sh
@@ -1,0 +1,245 @@
+#!/bin/sh
+# ci/ci-setup.sh
+#
+# CI helper for building and testing cups-browsed against several CUPS releases
+# on both native and QEMU-emulated runners.
+#
+# cups-browsed sits at the top of the OpenPrinting build stack: it needs libcups
+# AND libcupsfilters AND libppd.  For the source-CUPS leg the distro
+# libcupsfilters-dev / libppd-dev are built against CUPS 2.4 (wrong ABI), so this
+# script builds the whole chain (pdfio -> libcupsfilters -> libppd) from source
+# against the active CUPS before building cups-browsed on top.
+#
+# cups-browsed does NOT make sense on CUPS 3.x, so - unlike the other repos -
+# the matrix is only 2 CUPS releases (2.4.x and 2.5.x), never libcups3.
+#
+# Subcommands:
+#   deps                 install build dependencies
+#   cups <kind>          provide libcups; <kind> is one of:
+#                          system-2x    distro libcups2-dev  (CUPS 2.4.x)
+#                          source-2.5.x OpenPrinting/cups@master    (CUPS 2.5.x)
+#   pdfio                build/install pdfio (required by libcupsfilters)
+#   libcupsfilters <kind> provide libcupsfilters matching the active CUPS:
+#                          system-2x    distro libcupsfilters-dev
+#                          source-*     OpenPrinting/libcupsfilters@master
+#   libppd <kind>        provide libppd matching the active CUPS:
+#                          system-2x    distro libppd-dev
+#                          source-*     OpenPrinting/libppd@master
+#   build-cups-browsed   autogen + configure + make (build/link only)
+#
+# Environment knobs honoured by build-cups-browsed:
+#   CUPS_KIND   the <kind> above (controls the cups-config shim)
+#   EMULATED    "1" when running under QEMU emulation
+#
+# Override knobs (optional):
+#   LIBCUPSFILTERS_URL / LIBCUPSFILTERS_REF   source libcupsfilters build
+#   LIBPPD_URL / LIBPPD_REF                   source libppd build
+#
+# The script runs as root inside emulation containers and via sudo on native
+# runners; it detects which automatically.
+set -eu
+
+# Classify a failure so CI (and humans) can tell an upstream-dependency breakage
+# apart from a real cups-browsed failure.  Each invocation handles exactly one
+# subcommand, so $1 identifies which side failed: providing the
+# CUPS / libcupsfilters / libppd stack (built from @master on the source leg, an
+# unpinned moving target) vs building/testing cups-browsed itself.  The source
+# leg is non-blocking precisely because of the former class of transient
+# breakage; this label makes the distinction explicit.
+_subcmd="${1:-}"
+_classify_failure() {
+	rc=$?
+	[ "$rc" -eq 0 ] && exit 0
+	case "$_subcmd" in
+		cups|pdfio|libcupsfilters|libppd)
+			echo "::error::UPSTREAM-DEP-FAILED: '$_subcmd' failed while building the CUPS/libcupsfilters/libppd stack (from @master on the source leg). This is an upstream-dependency breakage, not a cups-browsed bug." ;;
+		build-cups-browsed)
+			echo "::error::CUPS-BROWSED-FAILED: cups-browsed $_subcmd failed." ;;
+	esac
+	exit "$rc"
+}
+trap _classify_failure EXIT
+
+PDFIO_VER=1.6.4
+LIBCUPSFILTERS_URL="${LIBCUPSFILTERS_URL:-https://github.com/OpenPrinting/libcupsfilters.git}"
+LIBCUPSFILTERS_REF="${LIBCUPSFILTERS_REF:-master}"
+LIBPPD_URL="${LIBPPD_URL:-https://github.com/OpenPrinting/libppd.git}"
+LIBPPD_REF="${LIBPPD_REF:-master}"
+
+SUDO=""
+[ "$(id -u)" -eq 0 ] || SUDO="sudo"
+
+# Make apt completely non-interactive.  Native GitHub runners ship needrestart,
+# whose service-restart prompt otherwise hangs the job forever; the emulated
+# containers do not have it, which is why only the native legs stalled.
+export DEBIAN_FRONTEND=noninteractive
+export NEEDRESTART_MODE=a
+export NEEDRESTART_SUSPEND=1
+
+# Source-built CUPS / libcupsfilters / libppd install their .pc files under
+# $prefix/lib[/<multiarch>]/pkgconfig; make sure pkg-config (and cups-browsed's
+# configure) can find them.
+ma=$(gcc -dumpmachine 2>/dev/null || echo "")
+PKG_CONFIG_PATH="/usr/lib/pkgconfig${ma:+:/usr/lib/$ma/pkgconfig}:/usr/local/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+export PKG_CONFIG_PATH
+
+apt_install() {
+	$SUDO apt-get update --fix-missing -y
+	$SUDO apt-get install -y "$@"
+}
+
+cmd_deps() {
+	# Union of cups-browsed's own build deps (glib / gio / avahi-glib) and the
+	# deps needed to build pdfio, libcupsfilters and libppd from source on the
+	# source-CUPS leg.
+	apt_install \
+		build-essential autoconf automake libtool libtool-bin pkg-config \
+		gettext autopoint autotools-dev cmake git wget tar make gcc g++ \
+		file dbus \
+		libglib2.0-dev libavahi-client-dev libavahi-common-dev \
+		libavahi-glib-dev libssl-dev libpam-dev libusb-1.0-0-dev \
+		zlib1g-dev libqpdf-dev libexif-dev liblcms2-dev libfontconfig1-dev \
+		libfreetype6-dev libcairo2-dev libjpeg-dev libpng-dev libtiff-dev \
+		libjxl-dev libpoppler-dev libpoppler-cpp-dev libdbus-1-dev \
+		libopenjp2-7-dev mupdf-tools poppler-utils ghostscript
+	# Never let a pre-shipped cups-browsed / libppd / libcupsfilters shadow the
+	# builds under test.
+	$SUDO apt-get remove -y cups-browsed libppd-dev libcupsfilters-dev || true
+}
+
+# Install a thin `cups-config` shim backed by pkg-config.  cups-browsed's
+# configure.ac hard-requires `cups-config`, but CUPS 2.5 (OpenPrinting/cups
+# master) has dropped it in favour of cups.pc.  --image is vestigial here
+# (cups-browsed #includes <cups/raster.h> but calls no cupsRaster* APIs, and
+# CUPS 2.5 folds the raster API into libcups), so the shim ignores it.
+install_cups_config_shim() {
+	shim=/usr/local/bin/cups-config
+	$SUDO tee "$shim" >/dev/null <<'SHIM'
+#!/bin/sh
+# Minimal cups-config shim backed by pkg-config (CUPS 2.5 dropped cups-config).
+cflags=$(pkg-config --cflags cups)
+libs=$(pkg-config --libs cups)
+ver=$(pkg-config --modversion cups)
+datadir=$(pkg-config --variable=cups_datadir cups 2>/dev/null)
+serverroot=$(pkg-config --variable=cups_serverroot cups 2>/dev/null)
+serverbin=$(pkg-config --variable=cups_serverbin cups 2>/dev/null)
+[ -n "$datadir" ] || datadir=/usr/share/cups
+[ -n "$serverroot" ] || serverroot=/etc/cups
+[ -n "$serverbin" ] || serverbin=/usr/lib/cups
+out=""
+for arg in "$@"; do
+	case "$arg" in
+		--cflags)     out="$out $cflags" ;;
+		--libs)       out="$out $libs" ;;
+		--image)      : ;;  # vestigial; folded into libcups on CUPS 2.5
+		--ldflags)    : ;;
+		--version)    out="$out $ver" ;;
+		--datadir)    out="$out $datadir" ;;
+		--serverroot) out="$out $serverroot" ;;
+		--serverbin)  out="$out $serverbin" ;;
+	esac
+done
+echo "$out"
+SHIM
+	$SUDO chmod +x "$shim"
+	echo "ci-setup: installed cups-config shim at $shim"
+}
+
+# build_autoconf <url> <ref> <submodule-flag> [configure-args...]
+build_autoconf() {
+	url="$1"; ref="$2"; sub="$3"; shift 3
+	echo "ci-setup: building $url @ $ref"
+	src="$(mktemp -d)"
+	git clone --depth 1 --branch "$ref" $sub "$url" "$src"
+	( cd "$src"
+	  [ -x ./configure ] || ./autogen.sh
+	  ./configure --prefix=/usr "$@" || ./configure --prefix=/usr
+	  make -j"$(nproc)"
+	  $SUDO make install )
+	$SUDO ldconfig || true
+}
+
+cmd_cups() {
+	kind="$1"
+	case "$kind" in
+		system-2x)
+			# Distro CUPS 2.4: libcups2-dev provides cups-config + headers.
+			apt_install libcups2-dev
+			;;
+		source-2.5.x)
+			# Force the multiarch libdir: CUPS's configure otherwise installs
+			# libcups into /usr/lib64 on 64-bit hosts, which is not on the
+			# default linker search path.
+			build_autoconf https://github.com/OpenPrinting/cups.git master "" \
+				--disable-systemd ${ma:+--libdir=/usr/lib/$ma}
+			install_cups_config_shim
+			;;
+		*)
+			echo "ci-setup: unknown/unsupported cups kind: $kind" >&2; exit 2 ;;
+	esac
+}
+
+cmd_pdfio() {
+	echo "ci-setup: building pdfio $PDFIO_VER"
+	src="$(mktemp -d)"
+	( cd "$src"
+	  wget -q "https://github.com/michaelrsweet/pdfio/releases/download/v$PDFIO_VER/pdfio-$PDFIO_VER.tar.gz"
+	  tar -xzf "pdfio-$PDFIO_VER.tar.gz"
+	  cd "pdfio-$PDFIO_VER"
+	  ./configure --prefix=/usr --enable-shared
+	  make all
+	  $SUDO make install )
+	$SUDO ldconfig || true
+}
+
+cmd_libcupsfilters() {
+	kind="$1"
+	case "$kind" in
+		system-2x)
+			apt_install libcupsfilters-dev
+			;;
+		source-*)
+			# Build libcupsfilters against the CUPS already installed above.
+			build_autoconf "$LIBCUPSFILTERS_URL" "$LIBCUPSFILTERS_REF" ""
+			;;
+		*)
+			echo "ci-setup: unknown libcupsfilters kind: $kind" >&2; exit 2 ;;
+	esac
+}
+
+cmd_libppd() {
+	kind="$1"
+	case "$kind" in
+		system-2x)
+			apt_install libppd-dev libppd2
+			;;
+		source-*)
+			# Build libppd against the CUPS + libcupsfilters installed above.
+			build_autoconf "$LIBPPD_URL" "$LIBPPD_REF" ""
+			;;
+		*)
+			echo "ci-setup: unknown libppd kind: $kind" >&2; exit 2 ;;
+	esac
+}
+
+cmd_build() {
+	./autogen.sh
+	./configure
+	make -j"$(nproc)" V=1
+
+	# Report which CUPS the configure step actually selected.
+	echo "ci-setup: configured against:"
+	grep -E "cups-config:|CUPS_VERSION|checking for cups" config.log 2>/dev/null | head || true
+}
+
+case "${1:-}" in
+	deps)               cmd_deps ;;
+	cups)               shift; cmd_cups "$@" ;;
+	pdfio)              cmd_pdfio ;;
+	libcupsfilters)     shift; cmd_libcupsfilters "$@" ;;
+	libppd)             shift; cmd_libppd "$@" ;;
+	build-cups-browsed) cmd_build ;;
+	*)
+		echo "usage: ci-setup.sh {deps | cups <kind> | pdfio | libcupsfilters <kind> | libppd <kind> | build-cups-browsed}" >&2
+		exit 2 ;;
+esac

--- a/daemon/cups-browsed.c
+++ b/daemon/cups-browsed.c
@@ -52,6 +52,26 @@
 #include <cupsfilters/ipp.h>
 #include <ppd/ppd.h>
 
+/*
+ * CUPS 2.5 renamed the printer-type flags to CUPS_PTYPE_* and, together with
+ * the removal of implicit classes, dropped CUPS_PRINTER_NOT_SHARED and
+ * CUPS_PRINTER_IMPLICIT.  The deprecated operation/state aliases used elsewhere
+ * in this file were replaced in-place with their canonical IPP_OP_* /
+ * IPP_PSTATE_* / IPP_JSTATE_* / HTTP_ENCRYPTION_* names (which exist in both
+ * CUPS 2.4 and 2.5), but these two printer-type flags have no name that works
+ * on both, so map them here.  CUPS_PRINTER_IMPLICIT collapses to 0 - a no-op in
+ * the printer-type mask it is OR'd into - since implicit classes no longer
+ * exist on CUPS 2.5.
+ */
+#if CUPS_VERSION_MAJOR > 2 || (CUPS_VERSION_MAJOR == 2 && CUPS_VERSION_MINOR >= 5)
+#  ifndef CUPS_PRINTER_NOT_SHARED
+#    define CUPS_PRINTER_NOT_SHARED CUPS_PTYPE_NOT_SHARED
+#  endif
+#  ifndef CUPS_PRINTER_IMPLICIT
+#    define CUPS_PRINTER_IMPLICIT 0
+#  endif
+#endif
+
 #include "cups-notifier.h"
 
 // Attribute to mark a CUPS queue as created by us
@@ -4165,7 +4185,7 @@ create_subscription ()
     return (0);
   }
 
-  req = ippNewRequest (IPP_CREATE_PRINTER_SUBSCRIPTION);
+  req = ippNewRequest (IPP_OP_CREATE_PRINTER_SUBSCRIPTIONS);
   ippAddString (req, IPP_TAG_OPERATION, IPP_TAG_URI,
 		"printer-uri", NULL, "/");
   ippAddString (req, IPP_TAG_SUBSCRIPTION, IPP_TAG_KEYWORD,
@@ -4210,7 +4230,7 @@ renew_subscription (int id)
     return (FALSE);
   }
 
-  req = ippNewRequest (IPP_RENEW_SUBSCRIPTION);
+  req = ippNewRequest (IPP_OP_RENEW_SUBSCRIPTION);
   ippAddInteger (req, IPP_TAG_OPERATION, IPP_TAG_INTEGER,
 		 "notify-subscription-id", id);
   ippAddString (req, IPP_TAG_OPERATION, IPP_TAG_URI,
@@ -4265,7 +4285,7 @@ cancel_subscription (int id)
     return;
   }
 
-  req = ippNewRequest (IPP_CANCEL_SUBSCRIPTION);
+  req = ippNewRequest (IPP_OP_CANCEL_SUBSCRIPTION);
   ippAddString (req, IPP_TAG_OPERATION, IPP_TAG_URI,
 		"printer-uri", NULL, "/");
   ippAddInteger (req, IPP_TAG_OPERATION, IPP_TAG_INTEGER,
@@ -4373,7 +4393,7 @@ is_disabled(const char *printer,
   ipp_t *request, *response;
   ipp_attribute_t *attr;
   const char *pname = NULL;
-  ipp_pstate_t pstate = IPP_PRINTER_IDLE;
+  ipp_pstate_t pstate = IPP_PSTATE_IDLE;
   const char *p;
   char *pstatemsg = NULL;
   static const char *pattrs[] =
@@ -4395,7 +4415,7 @@ is_disabled(const char *printer,
     return (NULL);
   }
 
-  request = ippNewRequest(CUPS_GET_PRINTERS);
+  request = ippNewRequest(IPP_OP_CUPS_GET_PRINTERS);
   ippAddStrings(request, IPP_TAG_OPERATION, IPP_TAG_KEYWORD,
 		"requested-attributes",
 		sizeof(pattrs) / sizeof(pattrs[0]),
@@ -4413,7 +4433,7 @@ is_disabled(const char *printer,
       if (attr == NULL)
 	break;
       pname = NULL;
-      pstate = IPP_PRINTER_IDLE;
+      pstate = IPP_PSTATE_IDLE;
       if (pstatemsg)
       {
 	free(pstatemsg);
@@ -4453,8 +4473,8 @@ is_disabled(const char *printer,
       {
 	switch (pstate)
 	{
-	  case IPP_PRINTER_IDLE:
-	  case IPP_PRINTER_PROCESSING:
+	  case IPP_PSTATE_IDLE:
+	  case IPP_PSTATE_PROCESSING:
 	      ippDelete(response);
 	      if (pstatemsg != NULL)
 	      {
@@ -4462,7 +4482,7 @@ is_disabled(const char *printer,
 		pstatemsg = NULL;
 	      }
 	      return (NULL);
-	  case IPP_PRINTER_STOPPED:
+	  case IPP_PSTATE_STOPPED:
 	      ippDelete(response);
 	      if (reason == NULL)
 		return (pstatemsg);
@@ -4523,7 +4543,7 @@ enable_printer (const char *printer)
 
   httpAssembleURIf(HTTP_URI_CODING_ALL, uri, sizeof(uri), "ipp", NULL,
 		   "localhost", 0, "/printers/%s", printer);
-  request = ippNewRequest (IPP_RESUME_PRINTER);
+  request = ippNewRequest (IPP_OP_RESUME_PRINTER);
   ippAddString (request, IPP_TAG_OPERATION, IPP_TAG_URI,
 		"printer-uri", NULL, uri);
   ippDelete(cupsDoRequest (http, request, "/admin/"));
@@ -4562,7 +4582,7 @@ disable_printer (const char *printer,
     reason = "Disabled by cups-browsed";
   httpAssembleURIf(HTTP_URI_CODING_ALL, uri, sizeof(uri), "ipp", NULL,
 		   "localhost", 0, "/printers/%s", printer);
-  request = ippNewRequest (IPP_PAUSE_PRINTER);
+  request = ippNewRequest (IPP_OP_PAUSE_PRINTER);
   ippAddString (request, IPP_TAG_OPERATION, IPP_TAG_URI,
 		"printer-uri", NULL, uri);
   ippAddString (request, IPP_TAG_OPERATION, IPP_TAG_TEXT,
@@ -4635,7 +4655,7 @@ get_cups_default_printer()
     return (NULL);
   }
 
-  request = ippNewRequest(CUPS_GET_DEFAULT);
+  request = ippNewRequest(IPP_OP_CUPS_GET_DEFAULT);
   // Default user
   ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
 	       "requesting-user-name", NULL, cupsUser());
@@ -5547,7 +5567,7 @@ on_job_state (CupsNotifier *object,
   ipp_t *request, *response, *printer_attributes = NULL;
   ipp_attribute_t *attr;
   const char *pname = NULL;
-  ipp_pstate_t pstate = IPP_PRINTER_IDLE;
+  ipp_pstate_t pstate = IPP_PSTATE_IDLE;
   int paccept = 0;
   int num_jobs, min_jobs = 99999999;
   char destination_uri[1024];
@@ -5585,7 +5605,7 @@ on_job_state (CupsNotifier *object,
   debug_printf("[CUPS Notification] Job State: %s\n",
 	       job_state_reasons);
   debug_printf("[CUPS Notification] Job is processing: %s\n",
-	       job_state == IPP_JOB_PROCESSING ? "Yes" : "No");
+	       job_state == IPP_JSTATE_PROCESSING ? "Yes" : "No");
 
   if (terminating)
   {
@@ -5621,7 +5641,7 @@ on_job_state (CupsNotifier *object,
     }
   }
 
-  if (job_id != 0 && job_state == IPP_JOB_PROCESSING)
+  if (job_id != 0 && job_state == IPP_JSTATE_PROCESSING)
   {
     // Printer started processing a job, check if it uses the implicitclass
     // backend and if so, we select the remote queue to which to send the job
@@ -5745,7 +5765,7 @@ on_job_state (CupsNotifier *object,
 	    debug_printf("IPP request to %s:%d successful.\n", p->host,
 			 p->port);
 	    pname = NULL;
-	    pstate = IPP_PRINTER_IDLE;
+	    pstate = IPP_PSTATE_IDLE;
 	    paccept = 0;
 	    for (attr = ippFirstAttribute(response); attr != NULL;
 		 attr = ippNextAttribute(response))
@@ -5755,7 +5775,7 @@ on_job_state (CupsNotifier *object,
 	      if (attr == NULL)
 		break;
 	      pname = NULL;
-	      pstate = IPP_PRINTER_IDLE;
+	      pstate = IPP_PSTATE_IDLE;
 	      paccept = 0;
 	      got_printer_info = 0;
 	      while (attr != NULL && ippGetGroupTag(attr) ==
@@ -5791,7 +5811,7 @@ on_job_state (CupsNotifier *object,
 			     p->uri, p->host, p->port);
 		switch (pstate)
 		{
-		  case IPP_PRINTER_IDLE:
+		  case IPP_PSTATE_IDLE:
 		      valid_dest_found = 1;
 		      dest_host = p->ip ? p->ip : p->host;
 		      strncpy(destination_uri, p->uri,
@@ -5803,7 +5823,7 @@ on_job_state (CupsNotifier *object,
 		      debug_printf("Printer %s on host %s, port %d is idle, take this as destination and stop searching.\n",
 				   p->uri, p->host, p->port);
 		      break;
-		  case IPP_PRINTER_PROCESSING:
+		  case IPP_PSTATE_PROCESSING:
 		      valid_dest_found = 1;
 		      if (LoadBalancingType == QUEUE_ON_SERVERS)
 		      {
@@ -5811,7 +5831,7 @@ on_job_state (CupsNotifier *object,
 			http_printer =
 			  httpConnectEncryptShortTimeout
 			    (p->ip ? p->ip : p->host, p->port,
-			     HTTP_ENCRYPT_IF_REQUESTED);
+			     HTTP_ENCRYPTION_IF_REQUESTED);
 			if (http_printer)
 			{
 			  num_jobs = get_number_of_jobs(http_printer, p->uri, 0,
@@ -5838,7 +5858,7 @@ on_job_state (CupsNotifier *object,
 			debug_printf("Printer %s on host %s, port %d is printing.\n",
 				     p->uri, p->host, p->port);
 		      break;
-		  case IPP_PRINTER_STOPPED:
+		  case IPP_PSTATE_STOPPED:
 		      debug_printf("Printer %s on host %s, port %d is disabled, skip it.\n",
 				   p->uri, p->host, p->port);
 		      break;
@@ -5855,7 +5875,7 @@ on_job_state (CupsNotifier *object,
 	    ippDelete(response);
 	    response = NULL;
 
-	    if (pstate == IPP_PRINTER_IDLE && paccept)
+	    if (pstate == IPP_PSTATE_IDLE && paccept)
 	    {
 	      q->last_printer = i;
 	      break;
@@ -6033,7 +6053,7 @@ on_job_state (CupsNotifier *object,
       cfFreeResolution(max_res, NULL);
       cfFreeResolution(min_res, NULL);
 
-      request = ippNewRequest(CUPS_ADD_MODIFY_PRINTER);
+      request = ippNewRequest(IPP_OP_CUPS_ADD_MODIFY_PRINTER);
       httpAssembleURIf(HTTP_URI_CODING_ALL, uri, sizeof(uri), "ipp", NULL,
 		       "localhost", 0, "/printers/%s", printer);
       ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI,
@@ -7420,7 +7440,7 @@ create_queue(void* arg)
 	  debug_printf("Setting printer-is-shared bit to make this queue permanent.\n");
 	else
 	  debug_printf("Unsetting printer-is-shared bit.\n");
-	request = ippNewRequest(CUPS_ADD_MODIFY_PRINTER);
+	request = ippNewRequest(IPP_OP_CUPS_ADD_MODIFY_PRINTER);
 	ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI,
 		     "printer-uri", NULL, uri);
 	ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
@@ -7483,7 +7503,7 @@ create_queue(void* arg)
 	  goto end;
 	}
 	// No jobs, remove the CUPS queue
-	request = ippNewRequest(CUPS_DELETE_PRINTER);
+	request = ippNewRequest(IPP_OP_CUPS_DELETE_PRINTER);
 	ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI,
 		     "printer-uri", NULL, uri);
 	ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
@@ -8073,7 +8093,7 @@ create_queue(void* arg)
   }
 
   // Create a new CUPS queue or modify the existing queue
-  request = ippNewRequest(CUPS_ADD_MODIFY_PRINTER);
+  request = ippNewRequest(IPP_OP_CUPS_ADD_MODIFY_PRINTER);
   ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI,
 	       "printer-uri", NULL, uri);
   // Default user
@@ -8081,7 +8101,7 @@ create_queue(void* arg)
 	       "requesting-user-name", NULL, cupsUser());
   // Queue should be enabled ...
   ippAddInteger(request, IPP_TAG_PRINTER, IPP_TAG_ENUM, "printer-state",
-		IPP_PRINTER_IDLE);
+		IPP_PSTATE_IDLE);
   // ... and accepting jobs
   ippAddBoolean(request, IPP_TAG_PRINTER, "printer-is-accepting-jobs", 1);
   // Location (only if the remote server actually provides a location string)
@@ -8172,7 +8192,7 @@ create_queue(void* arg)
   // queue is configurable via the NewIPPPrinterQueuesShared directive
   // in cups-browsed.conf
 
-  request = ippNewRequest(CUPS_ADD_MODIFY_PRINTER);
+  request = ippNewRequest(IPP_OP_CUPS_ADD_MODIFY_PRINTER);
   ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI,
 	       "printer-uri", NULL, uri);
   ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
@@ -8231,7 +8251,7 @@ create_queue(void* arg)
   if (want_raw)
   {
     debug_printf("Removing local PPD file for printer %s\n", p->queue_name);
-    request = ippNewRequest(CUPS_ADD_MODIFY_PRINTER);
+    request = ippNewRequest(IPP_OP_CUPS_ADD_MODIFY_PRINTER);
     ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI,
 		 "printer-uri", NULL, uri);
     ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
@@ -8522,7 +8542,7 @@ update_cups_queues(gpointer unused)
 	      // No jobs, remove the CUPS queue
 	      debug_printf("Removing local CUPS queue %s (%s).\n",
 			   p->queue_name, p->uri);
-	      request = ippNewRequest(CUPS_DELETE_PRINTER);
+	      request = ippNewRequest(IPP_OP_CUPS_DELETE_PRINTER);
 	      // Printer URI: ipp://localhost/printers/<queue name>
 	      httpAssembleURIf(HTTP_URI_CODING_ALL, uri, sizeof(uri), "ipp",
 			       NULL, "localhost", 0, "/printers/%s",
@@ -10876,7 +10896,7 @@ browse_poll_get_printers (browsepoll_t *context,
   debug_printf ("cups-browsed [BrowsePoll %s:%d]: CUPS-Get-Printers\n",
 		context->server, context->port);
 
-  request = ippNewRequest(CUPS_GET_PRINTERS);
+  request = ippNewRequest(IPP_OP_CUPS_GET_PRINTERS);
   if (context->major > 0)
   {
     debug_printf("cups-browsed [BrowsePoll %s:%d]: setting IPP version %d.%d\n",
@@ -10978,7 +10998,7 @@ browse_poll_create_subscription (browsepoll_t *context,
   if (http == NULL)
     return;
 
-  request = ippNewRequest(IPP_CREATE_PRINTER_SUBSCRIPTION);
+  request = ippNewRequest(IPP_OP_CREATE_PRINTER_SUBSCRIPTIONS);
   if (context->major > 0)
   {
     debug_printf("cups-browsed [BrowsePoll %s:%d]: setting IPP version %d.%d\n",
@@ -11047,7 +11067,7 @@ browse_poll_cancel_subscription (browsepoll_t *context)
 {
   ipp_t *request, *response = NULL;
   http_t *http = httpConnectEncryptShortTimeout (context->server, context->port,
-						 HTTP_ENCRYPT_IF_REQUESTED);
+						 HTTP_ENCRYPTION_IF_REQUESTED);
 
   if (http == NULL)
   {
@@ -11061,7 +11081,7 @@ browse_poll_cancel_subscription (browsepoll_t *context)
   debug_printf ("cups-browsed [BrowsePoll %s:%d]: IPP-Cancel-Subscription\n",
 		context->server, context->port);
 
-  request = ippNewRequest(IPP_CANCEL_SUBSCRIPTION);
+  request = ippNewRequest(IPP_OP_CANCEL_SUBSCRIPTION);
   if (context->major > 0)
   {
     debug_printf("cups-browsed [BrowsePoll %s:%d]: setting IPP version %d.%d\n",
@@ -11104,7 +11124,7 @@ browse_poll_get_notifications (browsepoll_t *context,
   if (http == NULL)
     return (FALSE);
 
-  request = ippNewRequest(IPP_GET_NOTIFICATIONS);
+  request = ippNewRequest(IPP_OP_GET_NOTIFICATIONS);
   if (context->major > 0)
   {
     debug_printf("cups-browsed [BrowsePoll %s:%d]: setting IPP version %d.%d\n",
@@ -11213,7 +11233,7 @@ browse_poll (gpointer data)
   res_init ();
 
   http = httpConnectEncryptShortTimeout (context->server, context->port,
-					 HTTP_ENCRYPT_IF_REQUESTED);
+					 HTTP_ENCRYPTION_IF_REQUESTED);
   if (http == NULL)
   {
     debug_printf("cups-browsed [BrowsePoll %s:%d]: failed to connect\n",


### PR DESCRIPTION
This adds CI to cups-browsed, which previously had none.

**Multi-architecture / multi-CUPS build matrix** (`.github/workflows/build.yml` + `ci/ci-setup.sh`): 4 architectures × 2 CUPS releases = 8 combinations.

- Architectures: amd64, arm64 (native runners) and armhf, riscv64 (QEMU-emulated).
- CUPS releases: 2.4.x (distro `libcups2-dev`) and 2.5.x (`OpenPrinting/cups@master`). CUPS 3.x is intentionally excluded, since cups-browsed does not make sense there.

cups-browsed sits on top of the whole stack, so `ci/ci-setup.sh` builds pdfio, libcupsfilters and libppd from source against the active CUPS before building cups-browsed. The 2.5 leg gets a small `cups-config` shim backed by `pkg-config`, since CUPS 2.5 dropped `cups-config` but cups-browsed's `configure.ac` still requires it. The `source-2.5.x` legs are non-blocking (they build against a moving `@master`), and `ci/ci-setup.sh` labels failures as `UPSTREAM-DEP-FAILED` vs `CUPS-BROWSED-FAILED`.

**Fix build against CUPS 2.5.** Adding the matrix immediately surfaced that cups-browsed did not compile against CUPS 2.5: it still used pre-2.2 enum aliases that libcups 2.5 removed. This is fixed by switching to the canonical names, which exist in both CUPS 2.4 and 2.5 (`IPP_OP_*`, `IPP_PSTATE_*`, `IPP_JSTATE_*`, `HTTP_ENCRYPTION_*`), plus a version-guarded shim for the two printer-type flags that have no name valid on both (`CUPS_PRINTER_NOT_SHARED` → `CUPS_PTYPE_NOT_SHARED`; `CUPS_PRINTER_IMPLICIT` → `0`, since implicit classes were removed in 2.5).

All 8 combinations pass. The functional suite (`test/run-tests.sh`) is not wired into CI yet: it needs a live D-Bus + Avahi/mDNS environment for its DNS-SD queue-creation + print round-trip, which is not reliably available on GitHub runners. Wiring that up is a planned follow-up; this matrix already gives build/link regression coverage across every supported architecture and CUPS release.
