### PR TITLE
Add static analysis CI (cppcheck and CodeQL)

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,34 @@
+name: cppcheck
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install cppcheck
+        run: |
+          # Retry to ride out transient Ubuntu mirror sync failures (matches build.yml)
+          sudo apt-get update -o Acquire::Retries=3
+          sudo apt-get install -y -o Acquire::Retries=3 cppcheck
+
+      - name: Run cppcheck
+        run: |
+          cppcheck \
+            --enable=warning,performance,portability \
+            --error-exitcode=1 \
+            --inline-suppr \
+            --suppress=missingIncludeSystem \
+            --suppress=unknownMacro \
+            -DVERSION="$(grep -oP 'AC_INIT\(\[[^\]]*\],\s*\[\K[^\]]*' configure.ac)" \
+            .

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,68 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'c-cpp' ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Update build environment
+        run: sudo apt-get update --fix-missing -y -o Acquire::Retries=3
+
+      # cups-browsed's own build dependencies against distro CUPS 2.4:
+      # cups-config (libcups2-dev), libcupsfilters, libppd, glib/gio and avahi.
+      # No source-CUPS build is needed here - static analysis only needs one
+      # clean build of cups-browsed itself to scan.
+      - name: Install prerequisites
+        run: |
+          sudo apt-get install -y -o Acquire::Retries=3 \
+            autoconf \
+            automake \
+            libtool \
+            libtool-bin \
+            pkg-config \
+            gettext \
+            autopoint \
+            libcups2-dev \
+            libcupsfilters-dev \
+            libppd-dev \
+            libglib2.0-dev \
+            libavahi-client-dev \
+            libavahi-common-dev \
+            libavahi-glib-dev
+
+      - name: Generate configure script
+        run: ./autogen.sh
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
This adds static analysis to cups-browsed, matching the rest of the OpenPrinting stack. It was the only active package without any static-analysis CI; every sibling (cups-filters, libcupsfilters, libppd, cpdb-*, pappl-retrofit, cups/libcups) already runs CodeQL, and most also run cppcheck.

cups-browsed was split out of **cups-filters**, so these two workflows mirror its parent's:

- **`cppcheck.yml`** — runs cppcheck with `--enable=warning,performance,portability` and `--error-exitcode=1` over the tree, with the same suppressions cups-filters uses.
- **`static-analysis.yml`** — CodeQL for `c-cpp` with the `+security-and-quality` query suite. It builds cups-browsed against distro CUPS 2.4 (`libcups2-dev` ships `cups-config`), plus libcupsfilters, libppd, glib/gio and avahi, then lets CodeQL analyze that build. Only a single clean build is needed to scan, so there is no multi-CUPS matrix here.

Both workflows are green on the fork. This complements the build matrix added in #68: that catches build/link regressions across architectures and CUPS releases, and this adds the security/quality scanning that the rest of the stack already has.
